### PR TITLE
Add tool descriptions, program/email tools, and fix lead-by-email endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Marketing ops, growth, and RevOps teams spend hours clicking through the Marketo
 - **Lead database** — get leads by ID or email, create or update leads in bulk, delete leads
 - **Activity & change logs** — fetch activities and field changes for any lead
 - **List membership** — add or remove leads from static lists
+- **Program management** — list, inspect, clone programs and retrieve program members
+- **Email operations** — list, inspect, and send sample emails for QA
 - **Automatic auth** — OAuth 2.0 client-credentials flow with token caching & refresh
 - **Stdio transport** — works out of the box with Claude Desktop, Cursor, and any MCP client that speaks stdio
 
@@ -125,14 +127,21 @@ Copy `.env.example` to `.env` for local development.
 | `marketo_update_channel` | Update an existing channel |
 | `marketo_delete_channel` | Delete a channel |
 | `marketo_get_lead_by_id` | Get a lead by numeric ID |
-| `marketo_get_lead_by_email` | Get a lead by email address |
-| `marketo_create_or_update_lead` | Bulk create or update leads |
+| `marketo_get_lead_by_email` | Look up a lead by email address (filter API) |
+| `marketo_create_or_update_lead` | Bulk create or update leads (max 300 per call) |
 | `marketo_delete_lead` | Delete a lead |
 | `marketo_get_lead_activities` | Fetch activities for a lead (paginated) |
 | `marketo_get_lead_changes` | Fetch field-change history for a lead |
 | `marketo_get_lead_lists` | Get lists that a lead belongs to |
 | `marketo_add_lead_to_list` | Add leads to a static list |
 | `marketo_remove_lead_from_list` | Remove leads from a static list |
+| `marketo_get_programs` | List programs (filter by type, folder, tag, or date range) |
+| `marketo_get_program_by_id` | Get a program by ID |
+| `marketo_clone_program` | Clone a program and all its local assets into a folder |
+| `marketo_get_program_members` | Get leads that are members of a program |
+| `marketo_get_emails` | List emails (filter by status) |
+| `marketo_get_email_by_id` | Get an email by ID |
+| `marketo_send_sample_email` | Send a sample/preview email for QA |
 
 Each tool accepts typed arguments validated with [zod](https://zod.dev/) and returns the raw Marketo JSON response. See the [Adobe Marketo REST API reference](https://developer.adobe.com/marketo-apis/api/) for field-level details.
 
@@ -158,6 +167,20 @@ Any MCP client that supports stdio servers will work. Point it at the built bina
   }
 }
 ```
+
+## Rate limits
+
+Marketo enforces several API rate limits. Keep these in mind when running batch operations:
+
+| Limit | Value |
+|---|---|
+| **Short-term** | 100 calls per 20 seconds per instance |
+| **Daily** | 50,000 calls per day |
+| **Concurrent** | 10 simultaneous connections |
+| **Bulk import** | 10 MB per file, 10 concurrent jobs |
+| **Bulk export** | 500 MB per day, 2 concurrent jobs |
+
+If you hit `606 Max rate limit reached`, wait 20 seconds before retrying. The Marketo REST API returns a `Retry-After` header in some cases.
 
 ## Troubleshooting
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ const tokenManager = new TokenManager(MARKETO_CLIENT_ID, MARKETO_CLIENT_SECRET);
 
 const server = new McpServer({
   name: 'MarketoAPI',
-  version: '1.1.0',
+  version: '1.2.0',
 });
 
 async function makeApiRequest(
@@ -80,6 +80,7 @@ function tool<T>(handler: (args: T) => Promise<unknown>) {
 
 server.tool(
   'marketo_get_forms',
+  'List forms in the Marketo instance. Filter by approval status (approved/draft) and paginate with maxReturn/offset. Returns form metadata including URL, status, and folder location.',
   {
     maxReturn: z.number().optional(),
     offset: z.number().optional(),
@@ -97,12 +98,14 @@ server.tool(
 
 server.tool(
   'marketo_get_form_by_id',
+  'Retrieve a single form by its numeric ID. Returns full form metadata including fields, submit button, and thank-you page configuration.',
   { formId: z.number() },
   tool(async ({ formId }) => makeApiRequest(`/asset/v1/form/${formId}.json`, 'GET'))
 );
 
 server.tool(
   'marketo_clone_form',
+  'Clone an existing form into a destination folder. The cloned form is created in draft status and must be approved before use.',
   {
     formId: z.number(),
     name: z.string(),
@@ -125,6 +128,7 @@ server.tool(
 
 server.tool(
   'marketo_approve_form',
+  'Approve a draft form, making it available for use in landing pages and embeds. Optionally include an approval comment.',
   {
     formId: z.number(),
     comment: z.string().optional(),
@@ -144,6 +148,7 @@ server.tool(
 
 server.tool(
   'marketo_get_smart_lists',
+  'List smart lists in the Marketo instance. Paginate with maxReturn (default 200) and offset. Returns smart list metadata including filter rules and folder location.',
   {
     maxReturn: z.number().optional(),
     offset: z.number().optional(),
@@ -159,6 +164,7 @@ server.tool(
 
 server.tool(
   'marketo_get_smart_list_by_id',
+  'Retrieve a single smart list by its numeric ID. Returns the smart list definition including filter rules and membership criteria.',
   { smartListId: z.number() },
   tool(async ({ smartListId }) =>
     makeApiRequest(`/asset/v1/smartList/${smartListId}.json`, 'GET')
@@ -171,6 +177,7 @@ server.tool(
 
 server.tool(
   'marketo_get_channels',
+  'List all program channels in the instance. Channels define the progression statuses available to programs (e.g., Webinar: Invited > Registered > Attended).',
   {
     maxReturn: z.number().optional(),
     offset: z.number().optional(),
@@ -186,12 +193,14 @@ server.tool(
 
 server.tool(
   'marketo_get_channel_by_id',
+  'Retrieve a single channel by its numeric ID. Returns the channel definition including progression statuses and their success mappings.',
   { channelId: z.number() },
   tool(async ({ channelId }) => makeApiRequest(`/asset/v1/channel/${channelId}.json`, 'GET'))
 );
 
 server.tool(
   'marketo_create_channel',
+  'Create a new program channel. Channels must have a unique name and type. The type determines which program types can use this channel.',
   {
     name: z.string(),
     description: z.string().optional(),
@@ -210,6 +219,7 @@ server.tool(
 
 server.tool(
   'marketo_update_channel',
+  'Update an existing channel\'s properties (name, description, type). Cannot change progression statuses after creation.',
   {
     channelId: z.number(),
     name: z.string().optional(),
@@ -229,6 +239,7 @@ server.tool(
 
 server.tool(
   'marketo_delete_channel',
+  'Delete a channel by ID. Fails if any programs are currently using this channel.',
   { channelId: z.number() },
   tool(async ({ channelId }) =>
     makeApiRequest(`/asset/v1/channel/${channelId}/delete.json`, 'POST')
@@ -242,6 +253,7 @@ server.tool(
 
 server.tool(
   'marketo_get_lead_by_id',
+  'Retrieve a lead by its numeric Marketo ID. Optionally specify which fields to return (defaults to standard fields). Returns lead record with all requested field values.',
   {
     leadId: z.number(),
     fields: z.array(z.string()).optional(),
@@ -256,20 +268,24 @@ server.tool(
 
 server.tool(
   'marketo_get_lead_by_email',
+  'Look up a lead by email address using the Marketo leads filter API. Optionally specify which fields to return. Returns matching lead records.',
   {
     email: z.string().email(),
     fields: z.array(z.string()).optional(),
   },
   tool(async ({ email, fields }) => {
-    const params = new URLSearchParams();
+    const params = new URLSearchParams({
+      filterType: 'email',
+      filterValues: email,
+    });
     if (fields) params.append('fields', fields.join(','));
-    const query = params.toString() ? `?${params.toString()}` : '';
-    return makeApiRequest(`/rest/v1/lead/${email}.json${query}`, 'GET');
+    return makeApiRequest(`/rest/v1/leads.json?${params.toString()}`, 'GET');
   })
 );
 
 server.tool(
   'marketo_create_or_update_lead',
+  'Bulk create or update leads (upsert). Accepts an array of lead records with standard and custom fields. Deduplicates by lookupField (default: email). Max 300 leads per call.',
   {
     input: z.array(
       z.object({
@@ -298,6 +314,7 @@ server.tool(
 
 server.tool(
   'marketo_delete_lead',
+  'Permanently delete a lead by its numeric ID. This action cannot be undone.',
   { leadId: z.number() },
   tool(async ({ leadId }) => makeApiRequest(`/rest/v1/leads/${leadId}/delete.json`, 'POST'))
 );
@@ -308,6 +325,7 @@ server.tool(
 
 server.tool(
   'marketo_get_lead_activities',
+  'Fetch activity records for a specific lead. Filter by activity type IDs (e.g., 1=Visit Webpage, 2=Fill Out Form, 6=Send Email). Supports cursor-based pagination via nextPageToken.',
   {
     leadId: z.number(),
     activityTypeIds: z.array(z.number()).optional(),
@@ -327,6 +345,7 @@ server.tool(
 
 server.tool(
   'marketo_get_lead_changes',
+  'Fetch field-change history for a specific lead. Optionally filter to specific field names. Useful for auditing data changes and tracking lead lifecycle progression.',
   {
     leadId: z.number(),
     fields: z.array(z.string()).optional(),
@@ -350,6 +369,7 @@ server.tool(
 
 server.tool(
   'marketo_get_lead_lists',
+  'Get all static lists that a lead belongs to. Supports cursor-based pagination via nextPageToken. Returns list IDs and names.',
   {
     leadId: z.number(),
     batchSize: z.number().optional(),
@@ -367,6 +387,7 @@ server.tool(
 
 server.tool(
   'marketo_add_lead_to_list',
+  'Add one or more leads to a static list by list ID. Accepts an array of lead IDs. Max 300 leads per call.',
   {
     listId: z.number(),
     leadIds: z.array(z.number()),
@@ -380,6 +401,7 @@ server.tool(
 
 server.tool(
   'marketo_remove_lead_from_list',
+  'Remove one or more leads from a static list. Accepts an array of lead IDs. Max 300 leads per call.',
   {
     listId: z.number(),
     leadIds: z.array(z.number()),
@@ -389,6 +411,137 @@ server.tool(
       input: leadIds.map(id => ({ id })),
     })
   )
+);
+
+// ============================================================================
+// Marketo Asset API — Programs
+// https://developer.adobe.com/marketo-apis/api/asset/#tag/Programs
+// ============================================================================
+
+server.tool(
+  'marketo_get_programs',
+  'List programs in Marketo. Filter by type (filterType: id, programType, folder, tag) with filterValues, or by date range (earliestUpdatedAt/latestUpdatedAt). Paginate with maxReturn/offset. Returns program metadata including channel, status, costs, and tags.',
+  {
+    maxReturn: z.number().optional(),
+    offset: z.number().optional(),
+    filterType: z.enum(['id', 'programType', 'folder', 'tag']).optional(),
+    filterValues: z.string().optional(),
+    earliestUpdatedAt: z.string().optional(),
+    latestUpdatedAt: z.string().optional(),
+  },
+  tool(async ({ maxReturn = 200, offset = 0, filterType, filterValues, earliestUpdatedAt, latestUpdatedAt }) => {
+    const params = new URLSearchParams({
+      maxReturn: maxReturn.toString(),
+      offset: offset.toString(),
+    });
+    if (filterType) params.append('filterType', filterType);
+    if (filterValues) params.append('filterValues', filterValues);
+    if (earliestUpdatedAt) params.append('earliestUpdatedAt', earliestUpdatedAt);
+    if (latestUpdatedAt) params.append('latestUpdatedAt', latestUpdatedAt);
+    return makeApiRequest(`/asset/v1/programs.json?${params.toString()}`, 'GET');
+  })
+);
+
+server.tool(
+  'marketo_get_program_by_id',
+  'Retrieve a single program by its numeric ID. Returns full program metadata including channel, status, costs, tags, and folder path.',
+  { programId: z.number() },
+  tool(async ({ programId }) => makeApiRequest(`/asset/v1/program/${programId}.json`, 'GET'))
+);
+
+server.tool(
+  'marketo_clone_program',
+  'Clone an existing program into a destination folder. Clones all local assets (emails, landing pages, smart campaigns) within the program. The cloned program is created with the same channel.',
+  {
+    programId: z.number(),
+    name: z.string(),
+    folderId: z.number(),
+    description: z.string().optional(),
+  },
+  tool(async ({ programId, name, folderId, description }) =>
+    makeApiRequest(
+      `/asset/v1/program/${programId}/clone.json`,
+      'POST',
+      {
+        name,
+        folder: JSON.stringify({ id: folderId, type: 'Folder' }),
+        description,
+      },
+      'application/x-www-form-urlencoded'
+    )
+  )
+);
+
+server.tool(
+  'marketo_get_program_members',
+  'Get leads that are members of a specific program. Optionally specify which fields to return. Supports cursor-based pagination via nextPageToken. Returns member status alongside lead data.',
+  {
+    programId: z.number(),
+    fields: z.array(z.string()).optional(),
+    batchSize: z.number().optional(),
+    nextPageToken: z.string().optional(),
+  },
+  tool(async ({ programId, fields, batchSize = 200, nextPageToken }) => {
+    const params = new URLSearchParams({ batchSize: batchSize.toString() });
+    if (fields) params.append('fields', fields.join(','));
+    if (nextPageToken) params.append('nextPageToken', nextPageToken);
+    return makeApiRequest(
+      `/rest/v1/leads/programs/${programId}.json?${params.toString()}`,
+      'GET'
+    );
+  })
+);
+
+// ============================================================================
+// Marketo Asset API — Emails
+// https://developer.adobe.com/marketo-apis/api/asset/#tag/Emails
+// ============================================================================
+
+server.tool(
+  'marketo_get_emails',
+  'List email assets in Marketo. Filter by approval status (approved/draft) and paginate with maxReturn/offset. Returns email metadata including subject line, from address, and template ID.',
+  {
+    maxReturn: z.number().optional(),
+    offset: z.number().optional(),
+    status: z.enum(['approved', 'draft']).optional(),
+  },
+  tool(async ({ maxReturn = 200, offset = 0, status }) => {
+    const params = new URLSearchParams({
+      maxReturn: maxReturn.toString(),
+      offset: offset.toString(),
+    });
+    if (status) params.append('status', status);
+    return makeApiRequest(`/asset/v1/emails.json?${params.toString()}`, 'GET');
+  })
+);
+
+server.tool(
+  'marketo_get_email_by_id',
+  'Retrieve a single email by its numeric ID. Returns full email metadata including subject, from address, reply-to, template, and folder location.',
+  { emailId: z.number() },
+  tool(async ({ emailId }) => makeApiRequest(`/asset/v1/email/${emailId}.json`, 'GET'))
+);
+
+server.tool(
+  'marketo_send_sample_email',
+  'Send a sample/preview of an email to a specified email address. Optionally render with a specific lead\'s data by passing leadId. Useful for QA before approving.',
+  {
+    emailId: z.number(),
+    emailAddress: z.string().email(),
+    textOnly: z.boolean().optional(),
+    leadId: z.number().optional(),
+  },
+  tool(async ({ emailId, emailAddress, textOnly, leadId }) => {
+    const data: Record<string, string> = { emailAddress };
+    if (textOnly !== undefined) data.textOnly = textOnly.toString();
+    if (leadId !== undefined) data.leadId = leadId.toString();
+    return makeApiRequest(
+      `/asset/v1/email/${emailId}/sendSample.json`,
+      'POST',
+      data,
+      'application/x-www-form-urlencoded'
+    );
+  })
 );
 
 const transport = new StdioServerTransport();


### PR DESCRIPTION
## Summary

- **Tool descriptions on all 20 existing tools** — every `server.tool()` call now includes a description string so MCP clients (Claude Desktop, Cursor, etc.) can show users what each tool does before calling it
- **7 new tools** — Programs (4) and Emails (3), following the same patterns already in the codebase
- **Bug fix: `marketo_get_lead_by_email`** — was hitting `/rest/v1/lead/{email}.json` (the ID-based endpoint) instead of the correct filter API at `/rest/v1/leads.json?filterType=email&filterValues={email}`
- **Rate-limit reference** — new section in README documenting Marketo's API rate limits (100/20s, 50k/day, 10 concurrent)
- **Version bump to 1.2.0**

## New tools

| Tool | API | Description |
|---|---|---|
| `marketo_get_programs` | Asset API | List programs with filtering (type, folder, tag, date range) and pagination |
| `marketo_get_program_by_id` | Asset API | Get a single program by ID |
| `marketo_clone_program` | Asset API | Clone a program and all local assets into a destination folder |
| `marketo_get_program_members` | Lead DB API | Get leads that are members of a program (with pagination) |
| `marketo_get_emails` | Asset API | List emails with status filtering and pagination |
| `marketo_get_email_by_id` | Asset API | Get a single email by ID |
| `marketo_send_sample_email` | Asset API | Send a preview email to a specified address for QA |

## Bug fix detail

`marketo_get_lead_by_email` was using:
```
GET /rest/v1/lead/{email}.json
```

This is the lead-by-ID endpoint and would return a 404 for email addresses. The correct endpoint is the filter API:
```
GET /rest/v1/leads.json?filterType=email&filterValues={email}
```

## Future work ideas

Some high-value Marketo API surfaces that could be added as follow-up PRs:

- **Landing Pages** — list, inspect, clone, approve (Asset API)
- **Smart Campaigns** — list, trigger, schedule, request campaign (Asset + Lead DB API)
- **Tokens** — get/set program-level tokens (Asset API)
- **Bulk Export** — create/enqueue/poll/download bulk lead/activity exports (Bulk API)
- **Snippets & Templates** — email template and snippet CRUD (Asset API)

## Test plan

- [x] `npm run build` compiles cleanly
- [x] All existing tool signatures unchanged (backwards compatible)
- [x] New tools follow identical patterns to existing ones
- [ ] Manual test with MCP inspector against a Marketo sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)